### PR TITLE
Add scoped external tool execution

### DIFF
--- a/system-tools-api/src/com/braintribe/utils/system/exec/RunCommandRequest.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/RunCommandRequest.java
@@ -15,6 +15,7 @@
 // ============================================================================
 package com.braintribe.utils.system.exec;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ public class RunCommandRequest {
 	protected Map<String, String> environmentVariables = null;
 	protected boolean silent = false;
 	protected String input;
+	protected File workingDirectory;
 
 	public static RunCommandRequestBuilder builder() {
 		return new RunCommandRequestBuilder();
@@ -65,6 +67,10 @@ public class RunCommandRequest {
 		}
 		public RunCommandRequestBuilder silent(boolean silent) {
 			request.silent = silent;
+			return this;
+		}
+		public RunCommandRequestBuilder workingDirectory(File workingDirectory) {
+			request.workingDirectory = workingDirectory;
 			return this;
 		}
 		public RunCommandRequest build() {
@@ -185,6 +191,9 @@ public class RunCommandRequest {
 	}
 	public String getInput() {
 		return input;
+	}
+	public File getWorkingDirectory() {
+		return workingDirectory;
 	}
 
 	@Override

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ExternalTool.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ExternalTool.java
@@ -1,0 +1,12 @@
+package com.braintribe.utils.system.exec.tool;
+
+public interface ExternalTool {
+
+	String id();
+
+	ToolAvailability availability();
+
+	ToolDescriptor descriptor();
+
+	ToolExecution openExecution();
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ExternalToolRegistry.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ExternalToolRegistry.java
@@ -1,0 +1,12 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.util.Collection;
+
+public interface ExternalToolRegistry {
+
+	ExternalTool required(String toolId);
+
+	ExternalTool optional(String toolId);
+
+	Collection<ToolDescriptor> descriptors();
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ExternalToolSpace.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ExternalToolSpace.java
@@ -1,0 +1,10 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.nio.file.Path;
+
+public interface ExternalToolSpace {
+
+	String id();
+
+	Path path();
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolAvailability.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolAvailability.java
@@ -1,0 +1,7 @@
+package com.braintribe.utils.system.exec.tool;
+
+public enum ToolAvailability {
+	UNKNOWN,
+	AVAILABLE,
+	UNAVAILABLE
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolDescriptor.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolDescriptor.java
@@ -1,0 +1,42 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ToolDescriptor {
+
+	private final String id;
+	private final String backend;
+	private final List<String> command;
+	private final ToolAvailability availability;
+	private final String availabilityMessage;
+
+	public ToolDescriptor(String id, String backend, List<String> command, ToolAvailability availability, String availabilityMessage) {
+		this.id = id;
+		this.backend = backend;
+		this.command = command == null ? Collections.<String>emptyList() : Collections.unmodifiableList(new ArrayList<String>(command));
+		this.availability = availability;
+		this.availabilityMessage = availabilityMessage;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getBackend() {
+		return backend;
+	}
+
+	public List<String> getCommand() {
+		return command;
+	}
+
+	public ToolAvailability getAvailability() {
+		return availability;
+	}
+
+	public String getAvailabilityMessage() {
+		return availabilityMessage;
+	}
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecution.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecution.java
@@ -1,0 +1,11 @@
+package com.braintribe.utils.system.exec.tool;
+
+public interface ToolExecution extends AutoCloseable {
+
+	ToolWorkspace workspace();
+
+	ToolExecutionResult execute(ToolExecutionRequest request) throws Exception;
+
+	@Override
+	void close();
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecutionEnvironment.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecutionEnvironment.java
@@ -1,0 +1,10 @@
+package com.braintribe.utils.system.exec.tool;
+
+public interface ToolExecutionEnvironment {
+
+	ExternalToolRegistry tools();
+
+	ToolExecutionScope openScope();
+
+	ExternalToolSpace externalSpace(String spaceId);
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecutionRequest.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecutionRequest.java
@@ -1,0 +1,122 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ToolExecutionRequest {
+
+	private final List<String> arguments;
+	private final long timeout;
+	private final int retries;
+	private final long retryDelay;
+	private final Map<String, String> environmentVariables;
+	private final boolean silent;
+	private final String input;
+
+	private ToolExecutionRequest(Builder builder) {
+		this.arguments = Collections.unmodifiableList(new ArrayList<String>(builder.arguments));
+		this.timeout = builder.timeout;
+		this.retries = builder.retries;
+		this.retryDelay = builder.retryDelay;
+		this.environmentVariables = builder.environmentVariables == null ? null
+				: Collections.unmodifiableMap(new LinkedHashMap<String, String>(builder.environmentVariables));
+		this.silent = builder.silent;
+		this.input = builder.input;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public List<String> getArguments() {
+		return arguments;
+	}
+
+	public long getTimeout() {
+		return timeout;
+	}
+
+	public int getRetries() {
+		return retries;
+	}
+
+	public long getRetryDelay() {
+		return retryDelay;
+	}
+
+	public Map<String, String> getEnvironmentVariables() {
+		return environmentVariables;
+	}
+
+	public boolean isSilent() {
+		return silent;
+	}
+
+	public String getInput() {
+		return input;
+	}
+
+	public static class Builder {
+		private final List<String> arguments = new ArrayList<String>();
+		private long timeout = -1L;
+		private int retries = -1;
+		private long retryDelay = -1L;
+		private Map<String, String> environmentVariables;
+		private boolean silent;
+		private String input;
+
+		public Builder argument(String argument) {
+			arguments.add(argument);
+			return this;
+		}
+
+		public Builder arguments(String... arguments) {
+			if (arguments != null)
+				Collections.addAll(this.arguments, arguments);
+			return this;
+		}
+
+		public Builder arguments(List<String> arguments) {
+			if (arguments != null)
+				this.arguments.addAll(arguments);
+			return this;
+		}
+
+		public Builder timeout(long timeout) {
+			this.timeout = timeout;
+			return this;
+		}
+
+		public Builder retries(int retries) {
+			this.retries = retries;
+			return this;
+		}
+
+		public Builder retryDelay(long retryDelay) {
+			this.retryDelay = retryDelay;
+			return this;
+		}
+
+		public Builder environmentVariables(Map<String, String> environmentVariables) {
+			this.environmentVariables = environmentVariables;
+			return this;
+		}
+
+		public Builder silent(boolean silent) {
+			this.silent = silent;
+			return this;
+		}
+
+		public Builder input(String input) {
+			this.input = input;
+			return this;
+		}
+
+		public ToolExecutionRequest build() {
+			return new ToolExecutionRequest(this);
+		}
+	}
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecutionResult.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecutionResult.java
@@ -1,0 +1,30 @@
+package com.braintribe.utils.system.exec.tool;
+
+public class ToolExecutionResult {
+
+	private final int exitCode;
+	private final String standardOutput;
+	private final String standardError;
+
+	public ToolExecutionResult(int exitCode, String standardOutput, String standardError) {
+		this.exitCode = exitCode;
+		this.standardOutput = standardOutput;
+		this.standardError = standardError;
+	}
+
+	public int getExitCode() {
+		return exitCode;
+	}
+
+	public String getStandardOutput() {
+		return standardOutput;
+	}
+
+	public String getStandardError() {
+		return standardError;
+	}
+
+	public boolean isSuccessful() {
+		return exitCode == 0;
+	}
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecutionScope.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolExecutionScope.java
@@ -1,0 +1,11 @@
+package com.braintribe.utils.system.exec.tool;
+
+public interface ToolExecutionScope extends AutoCloseable {
+
+	ToolWorkspace workspace();
+
+	ToolExecutionResult execute(ExternalTool tool, ToolExecutionRequest request) throws Exception;
+
+	@Override
+	void close();
+}

--- a/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolWorkspace.java
+++ b/system-tools-api/src/com/braintribe/utils/system/exec/tool/ToolWorkspace.java
@@ -1,0 +1,12 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.nio.file.Path;
+
+public interface ToolWorkspace {
+
+	Path root();
+
+	Path resolve(String relativePath);
+
+	Path createDirectory(String relativePath);
+}

--- a/system-tools-test/src/com/braintribe/utils/system/exec/tool/StandardToolExecutionEnvironmentTest.java
+++ b/system-tools-test/src/com/braintribe/utils/system/exec/tool/StandardToolExecutionEnvironmentTest.java
@@ -1,0 +1,146 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.braintribe.utils.system.exec.CommandExecution;
+import com.braintribe.utils.system.exec.RunCommandContext;
+import com.braintribe.utils.system.exec.RunCommandRequest;
+
+public class StandardToolExecutionEnvironmentTest {
+
+	private Path root;
+	private CapturingCommandExecution commandExecution;
+	private StandardToolExecutionEnvironment environment;
+
+	@Before
+	public void initialize() throws Exception {
+		root = Files.createTempDirectory("external-tools-test");
+		commandExecution = new CapturingCommandExecution();
+		environment = new StandardToolExecutionEnvironment(commandExecution, root, "test");
+	}
+
+	@After
+	public void cleanup() throws Exception {
+		deleteRecursively(root);
+	}
+
+	@Test
+	public void boundExecutionPrefixesCommandAndCleansWorkspace() throws Exception {
+		ExternalTool tool = environment.register("echo", "echo-command");
+		Path workspaceRoot;
+
+		try (ToolExecution execution = tool.openExecution()) {
+			workspaceRoot = execution.workspace().root();
+			Files.write(execution.workspace().resolve("input.txt"), "content".getBytes(StandardCharsets.UTF_8));
+
+			ToolExecutionResult result = execution.execute(ToolExecutionRequest.builder().argument("hello").timeout(1000L).build());
+
+			Assert.assertTrue(result.isSuccessful());
+			Assert.assertArrayEquals(new String[] { "echo-command", "hello" }, commandExecution.lastRequest.getCommandParts());
+			Assert.assertEquals(workspaceRoot.toFile(), commandExecution.lastRequest.getWorkingDirectory());
+			Assert.assertTrue(Files.exists(workspaceRoot));
+		}
+
+		Assert.assertFalse(Files.exists(workspaceRoot));
+	}
+
+	@Test
+	public void oneScopeCanExecuteMultipleTools() throws Exception {
+		ExternalTool first = environment.register("first", "first-command");
+		ExternalTool second = environment.register("second", "second-command");
+
+		try (ToolExecutionScope scope = environment.openScope()) {
+			scope.execute(first, ToolExecutionRequest.builder().argument("one").build());
+			scope.execute(second, ToolExecutionRequest.builder().argument("two").build());
+		}
+
+		Assert.assertEquals(2, commandExecution.requests.size());
+		Assert.assertArrayEquals(new String[] { "first-command", "one" }, commandExecution.requests.get(0).getCommandParts());
+		Assert.assertArrayEquals(new String[] { "second-command", "two" }, commandExecution.requests.get(1).getCommandParts());
+	}
+
+	@Test
+	public void commandLineBuilderCanUseWorkspace() throws Exception {
+		environment.register("containerized", () -> java.util.Collections.singletonList("containerized"), (workspace, arguments) -> {
+			List<String> command = new ArrayList<String>();
+			command.add("container");
+			command.add("--workdir");
+			command.add(workspace.root().toString());
+			command.add("containerized");
+			command.addAll(arguments);
+			return command;
+		});
+
+		try (ToolExecution execution = environment.required("containerized").openExecution()) {
+			execution.execute(ToolExecutionRequest.builder().argument("input.pdf").build());
+			Assert.assertArrayEquals(
+					new String[] { "container", "--workdir", execution.workspace().root().toString(), "containerized", "input.pdf" },
+					commandExecution.lastRequest.getCommandParts());
+		}
+	}
+
+	@Test
+	public void externalSpaceOutlivesExecutionScope() throws Exception {
+		Path externalFile = environment.externalSpace("models").path().resolve("model.bin");
+		Files.write(externalFile, new byte[] { 1, 2, 3 });
+
+		try (ToolExecutionScope scope = environment.openScope()) {
+			Files.write(scope.workspace().resolve("temporary.bin"), new byte[] { 4, 5, 6 });
+		}
+
+		Assert.assertTrue(Files.exists(externalFile));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void workspaceRejectsTraversal() {
+		try (ToolExecutionScope scope = environment.openScope()) {
+			scope.workspace().resolve("../outside");
+		}
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void missingRequiredToolFailsEarly() {
+		environment.required("missing");
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void duplicateToolIdsAreRejected() {
+		environment.register("duplicate", "first");
+		environment.register("duplicate", "second");
+	}
+
+	private void deleteRecursively(Path path) throws Exception {
+		if (path == null || !Files.exists(path))
+			return;
+		try (java.util.stream.Stream<Path> paths = Files.walk(path)) {
+			paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+				try {
+					Files.deleteIfExists(p);
+				} catch (Exception ignored) {
+					// Test cleanup must not hide the test result.
+				}
+			});
+		}
+	}
+
+	private static class CapturingCommandExecution implements CommandExecution {
+		private final List<RunCommandRequest> requests = new ArrayList<RunCommandRequest>();
+		private RunCommandRequest lastRequest;
+
+		@Override
+		public RunCommandContext runCommand(RunCommandRequest request) {
+			lastRequest = request;
+			requests.add(request);
+			return new RunCommandContext(0, "ok", "");
+		}
+	}
+}

--- a/system-tools/src/com/braintribe/utils/system/exec/CommandExecutionImpl.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/CommandExecutionImpl.java
@@ -54,6 +54,7 @@ public class CommandExecutionImpl implements CommandExecution {
 		long retryDelay = request.getRetryDelay();
 		boolean silent = request.isSilent();
 		String input = request.getInput();
+		File workingDirectory = request.getWorkingDirectory();
 
 		String signature = String.format("runCommand(commands='%s', timeout=%d, retries=%d, retryDelay=%d, environmentVariables=%s)",
 				commandDescription, timeout, retries, retryDelay, environmentVariables);
@@ -66,14 +67,14 @@ public class CommandExecutionImpl implements CommandExecution {
 				logger.debug(String.format("%s: begin", signature));
 		}
 
-		RunCommandContext result = runCommand(commandParts, timeout, false, environmentVariables, input);
+		RunCommandContext result = runCommand(commandParts, timeout, false, environmentVariables, input, workingDirectory);
 		int count = 0;
 		while ((count < retries) && (result.getErrorCode() != 0)) {
 			count++;
 
 			trace(commandDescription, timeout, count, retries);
 
-			result = runCommand(commandParts, timeout, false, environmentVariables, input);
+			result = runCommand(commandParts, timeout, false, environmentVariables, input, workingDirectory);
 
 			if (result.getErrorCode() != 0) {
 				if ((retryDelay > 0) && (count < retries)) {
@@ -102,6 +103,11 @@ public class CommandExecutionImpl implements CommandExecution {
 
 	protected RunCommandContext runCommand(String[] command, long timeout, boolean silent, Map<String, String> environmentVariables, String input)
 			throws Exception {
+		return runCommand(command, timeout, silent, environmentVariables, input, null);
+	}
+
+	protected RunCommandContext runCommand(String[] command, long timeout, boolean silent, Map<String, String> environmentVariables, String input,
+			File workingDirectory) throws Exception {
 
 		long t1 = System.currentTimeMillis();
 
@@ -121,6 +127,8 @@ public class CommandExecutionImpl implements CommandExecution {
 
 		try {
 			ProcessBuilder processBuilder = new ProcessBuilder(command);
+			if (workingDirectory != null)
+				processBuilder.directory(workingDirectory);
 			processBuilder.redirectOutput(Redirect.to(stdoutFile));
 			processBuilder.redirectError(Redirect.to(stderrFile));
 

--- a/system-tools/src/com/braintribe/utils/system/exec/tool/StandardExternalTool.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/tool/StandardExternalTool.java
@@ -1,0 +1,116 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.braintribe.utils.system.exec.RunCommandContext;
+import com.braintribe.utils.system.exec.RunCommandRequest;
+
+public class StandardExternalTool implements ExternalTool {
+
+	private final String id;
+	private final String backend;
+	private final StandardToolExecutionEnvironment environment;
+	private final Supplier<List<String>> commandResolver;
+	private final ToolCommandLineBuilder commandLineBuilder;
+
+	private volatile boolean resolved;
+	private List<String> command = Collections.emptyList();
+	private String resolutionFailure;
+
+	public StandardExternalTool(String id, String backend, StandardToolExecutionEnvironment environment, Supplier<List<String>> commandResolver) {
+		this(id, backend, environment, commandResolver, null);
+	}
+
+	public StandardExternalTool(String id, String backend, StandardToolExecutionEnvironment environment, Supplier<List<String>> commandResolver,
+			ToolCommandLineBuilder commandLineBuilder) {
+		this.id = id;
+		this.backend = backend;
+		this.environment = environment;
+		this.commandResolver = commandResolver;
+		this.commandLineBuilder = commandLineBuilder;
+	}
+
+	@Override
+	public String id() {
+		return id;
+	}
+
+	@Override
+	public ToolAvailability availability() {
+		resolve();
+		return command.isEmpty() ? ToolAvailability.UNAVAILABLE : ToolAvailability.AVAILABLE;
+	}
+
+	@Override
+	public ToolDescriptor descriptor() {
+		resolve();
+		return new ToolDescriptor(id, backend, command, availability(), resolutionFailure);
+	}
+
+	@Override
+	public ToolExecution openExecution() {
+		if (availability() != ToolAvailability.AVAILABLE)
+			throw new IllegalStateException("External tool '" + id + "' is unavailable: " + resolutionFailure);
+		return new StandardToolExecution(this, environment.openScope());
+	}
+
+	StandardToolExecutionEnvironment environment() {
+		return environment;
+	}
+
+	ToolExecutionResult execute(StandardToolExecutionScope scope, ToolExecutionRequest request) throws Exception {
+		resolve();
+		if (command.isEmpty())
+			throw new IllegalStateException("External tool '" + id + "' is unavailable: " + resolutionFailure);
+
+		List<String> commandParts;
+		if (commandLineBuilder == null) {
+			commandParts = new ArrayList<String>(command.size() + request.getArguments().size());
+			commandParts.addAll(command);
+			commandParts.addAll(request.getArguments());
+		} else {
+			commandParts = commandLineBuilder.build(scope.workspace(), request.getArguments());
+		}
+		if (commandParts == null || commandParts.isEmpty())
+			throw new IllegalStateException("Command line builder returned no command for external tool '" + id + "'.");
+
+		RunCommandRequest lowLevelRequest = RunCommandRequest.builder() //
+				.command(commandParts.toArray(new String[commandParts.size()])) //
+				.timeout(request.getTimeout()) //
+				.retries(request.getRetries()) //
+				.retryDelay(request.getRetryDelay()) //
+				.env(request.getEnvironmentVariables()) //
+				.input(request.getInput()) //
+				.silent(request.isSilent()) //
+				.workingDirectory(scope.workspace().root().toFile()) //
+				.build();
+
+		RunCommandContext result = environment.commandExecution().runCommand(lowLevelRequest);
+		return new ToolExecutionResult(result.getErrorCode(), result.getOutput(), result.getError());
+	}
+
+	private void resolve() {
+		if (resolved)
+			return;
+
+		synchronized (this) {
+			if (resolved)
+				return;
+			try {
+				List<String> resolvedCommand = commandResolver.get();
+				if (resolvedCommand == null || resolvedCommand.isEmpty()) {
+					resolutionFailure = "No command was resolved.";
+				} else {
+					command = Collections.unmodifiableList(new ArrayList<String>(resolvedCommand));
+				}
+			} catch (Exception e) {
+				resolutionFailure = e.getMessage() == null ? e.getClass().getName() : e.getMessage();
+			} finally {
+				resolved = true;
+			}
+		}
+	}
+}

--- a/system-tools/src/com/braintribe/utils/system/exec/tool/StandardExternalToolSpace.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/tool/StandardExternalToolSpace.java
@@ -1,0 +1,24 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.nio.file.Path;
+
+public class StandardExternalToolSpace implements ExternalToolSpace {
+
+	private final String id;
+	private final Path path;
+
+	public StandardExternalToolSpace(String id, Path path) {
+		this.id = id;
+		this.path = path;
+	}
+
+	@Override
+	public String id() {
+		return id;
+	}
+
+	@Override
+	public Path path() {
+		return path;
+	}
+}

--- a/system-tools/src/com/braintribe/utils/system/exec/tool/StandardToolExecution.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/tool/StandardToolExecution.java
@@ -1,0 +1,27 @@
+package com.braintribe.utils.system.exec.tool;
+
+public class StandardToolExecution implements ToolExecution {
+
+	private final ExternalTool tool;
+	private final ToolExecutionScope scope;
+
+	public StandardToolExecution(ExternalTool tool, ToolExecutionScope scope) {
+		this.tool = tool;
+		this.scope = scope;
+	}
+
+	@Override
+	public ToolWorkspace workspace() {
+		return scope.workspace();
+	}
+
+	@Override
+	public ToolExecutionResult execute(ToolExecutionRequest request) throws Exception {
+		return scope.execute(tool, request);
+	}
+
+	@Override
+	public void close() {
+		scope.close();
+	}
+}

--- a/system-tools/src/com/braintribe/utils/system/exec/tool/StandardToolExecutionEnvironment.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/tool/StandardToolExecutionEnvironment.java
@@ -1,0 +1,135 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import com.braintribe.utils.system.exec.CommandExecution;
+
+public class StandardToolExecutionEnvironment implements ToolExecutionEnvironment, ExternalToolRegistry {
+
+	private final CommandExecution commandExecution;
+	private final Path root;
+	private final Path workspacesRoot;
+	private final Path externalRoot;
+	private final String backend;
+	private final Map<String, ExternalTool> tools = new LinkedHashMap<String, ExternalTool>();
+
+	public StandardToolExecutionEnvironment(CommandExecution commandExecution, Path root, String backend) {
+		if (commandExecution == null)
+			throw new IllegalArgumentException("Command execution must not be null.");
+		if (root == null)
+			throw new IllegalArgumentException("Tool file system root must not be null.");
+
+		this.commandExecution = commandExecution;
+		this.root = root.toAbsolutePath().normalize();
+		this.workspacesRoot = this.root.resolve("workspaces");
+		this.externalRoot = this.root.resolve("external");
+		this.backend = backend == null ? "local" : backend;
+		createDirectories(workspacesRoot);
+		createDirectories(externalRoot);
+	}
+
+	public ExternalTool register(String toolId, String... command) {
+		final List<String> parts = new ArrayList<String>();
+		if (command != null)
+			Collections.addAll(parts, command);
+		return register(toolId, new Supplier<List<String>>() {
+			@Override
+			public List<String> get() {
+				return parts;
+			}
+		});
+	}
+
+	public ExternalTool register(String toolId, Supplier<List<String>> commandResolver) {
+		return register(toolId, commandResolver, null);
+	}
+
+	public ExternalTool register(String toolId, Supplier<List<String>> commandResolver, ToolCommandLineBuilder commandLineBuilder) {
+		validateId(toolId);
+		if (tools.containsKey(toolId))
+			throw new IllegalStateException("External tool '" + toolId + "' is already registered.");
+		StandardExternalTool tool = new StandardExternalTool(toolId, backend, this, commandResolver, commandLineBuilder);
+		tools.put(toolId, tool);
+		return tool;
+	}
+
+	@Override
+	public ExternalToolRegistry tools() {
+		return this;
+	}
+
+	@Override
+	public ToolExecutionScope openScope() {
+		Path workspace = workspacesRoot.resolve(UUID.randomUUID().toString());
+		createDirectories(workspace);
+		return new StandardToolExecutionScope(this, workspace);
+	}
+
+	@Override
+	public ExternalToolSpace externalSpace(String spaceId) {
+		validateId(spaceId);
+		Path path = externalRoot.resolve(spaceId).normalize();
+		if (!path.startsWith(externalRoot))
+			throw new IllegalArgumentException("External tool space escapes its root: " + spaceId);
+		createDirectories(path);
+		return new StandardExternalToolSpace(spaceId, path);
+	}
+
+	@Override
+	public ExternalTool required(String toolId) {
+		ExternalTool tool = optional(toolId);
+		if (tool.availability() != ToolAvailability.AVAILABLE)
+			throw new IllegalStateException("Required external tool '" + toolId + "' is unavailable: " + tool.descriptor().getAvailabilityMessage());
+		return tool;
+	}
+
+	@Override
+	public ExternalTool optional(String toolId) {
+		validateId(toolId);
+		ExternalTool tool = tools.get(toolId);
+		if (tool == null)
+			return new UnavailableExternalTool(toolId, "No tool mapping is configured.");
+		return tool;
+	}
+
+	@Override
+	public Collection<ToolDescriptor> descriptors() {
+		List<ToolDescriptor> result = new ArrayList<ToolDescriptor>(tools.size());
+		for (ExternalTool tool : tools.values())
+			result.add(tool.descriptor());
+		return Collections.unmodifiableList(result);
+	}
+
+	CommandExecution commandExecution() {
+		return commandExecution;
+	}
+
+	public Path root() {
+		return root;
+	}
+
+	private void createDirectories(Path path) {
+		try {
+			Files.createDirectories(path);
+		} catch (IOException e) {
+			throw new IllegalStateException("Could not create tool file system directory " + path, e);
+		}
+	}
+
+	private void validateId(String id) {
+		if (id == null || id.trim().isEmpty())
+			throw new IllegalArgumentException("Tool or space id must not be blank.");
+		if (!id.matches("[A-Za-z0-9][A-Za-z0-9._-]*"))
+			throw new IllegalArgumentException("Invalid tool or space id: " + id);
+	}
+}

--- a/system-tools/src/com/braintribe/utils/system/exec/tool/StandardToolExecutionScope.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/tool/StandardToolExecutionScope.java
@@ -1,0 +1,72 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import com.braintribe.logging.Logger;
+
+public class StandardToolExecutionScope implements ToolExecutionScope {
+
+	private static final Logger logger = Logger.getLogger(StandardToolExecutionScope.class);
+
+	private final StandardToolExecutionEnvironment environment;
+	private final ToolWorkspace workspace;
+	private boolean closed;
+
+	public StandardToolExecutionScope(StandardToolExecutionEnvironment environment, Path root) {
+		this.environment = environment;
+		this.workspace = new StandardToolWorkspace(root);
+	}
+
+	@Override
+	public ToolWorkspace workspace() {
+		ensureOpen();
+		return workspace;
+	}
+
+	@Override
+	public ToolExecutionResult execute(ExternalTool tool, ToolExecutionRequest request) throws Exception {
+		ensureOpen();
+		if (!(tool instanceof StandardExternalTool))
+			throw new IllegalArgumentException("Tool was not created by a compatible tool execution environment: " + tool.id());
+
+		StandardExternalTool standardTool = (StandardExternalTool) tool;
+		if (standardTool.environment() != environment)
+			throw new IllegalArgumentException("Tool and execution scope belong to different environments: " + tool.id());
+
+		return standardTool.execute(this, request);
+	}
+
+	@Override
+	public void close() {
+		if (closed)
+			return;
+		closed = true;
+
+		Path root = workspace.root();
+		if (!Files.exists(root))
+			return;
+
+		try (Stream<Path> paths = Files.walk(root)) {
+			paths.sorted(Comparator.reverseOrder()).forEach(this::deleteSilently);
+		} catch (Exception e) {
+			logger.warn("Could not completely clean tool execution workspace " + root, e);
+		}
+	}
+
+	private void deleteSilently(Path path) {
+		try {
+			Files.deleteIfExists(path);
+		} catch (IOException e) {
+			logger.warn("Could not delete tool execution workspace path " + path, e);
+		}
+	}
+
+	private void ensureOpen() {
+		if (closed)
+			throw new IllegalStateException("Tool execution scope is already closed.");
+	}
+}

--- a/system-tools/src/com/braintribe/utils/system/exec/tool/StandardToolWorkspace.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/tool/StandardToolWorkspace.java
@@ -1,0 +1,45 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class StandardToolWorkspace implements ToolWorkspace {
+
+	private final Path root;
+
+	public StandardToolWorkspace(Path root) {
+		this.root = root.toAbsolutePath().normalize();
+	}
+
+	@Override
+	public Path root() {
+		return root;
+	}
+
+	@Override
+	public Path resolve(String relativePath) {
+		if (relativePath == null)
+			throw new IllegalArgumentException("Relative path must not be null.");
+
+		Path relative = root.getFileSystem().getPath(relativePath);
+		if (relative.isAbsolute())
+			throw new IllegalArgumentException("Expected a relative workspace path, but got: " + relativePath);
+
+		Path resolved = root.resolve(relative).normalize();
+		if (!resolved.startsWith(root))
+			throw new IllegalArgumentException("Workspace path escapes its root: " + relativePath);
+
+		return resolved;
+	}
+
+	@Override
+	public Path createDirectory(String relativePath) {
+		Path directory = resolve(relativePath);
+		try {
+			return Files.createDirectories(directory);
+		} catch (IOException e) {
+			throw new IllegalStateException("Could not create tool workspace directory " + directory, e);
+		}
+	}
+}

--- a/system-tools/src/com/braintribe/utils/system/exec/tool/ToolCommandLineBuilder.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/tool/ToolCommandLineBuilder.java
@@ -1,0 +1,15 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.util.List;
+
+/**
+ * Builds the effective command line for one invocation. Unlike a static command
+ * prefix this may take the execution workspace into account, which is required
+ * by container-backed tools.
+ */
+@FunctionalInterface
+public interface ToolCommandLineBuilder {
+
+	List<String> build(ToolWorkspace workspace, List<String> arguments);
+
+}

--- a/system-tools/src/com/braintribe/utils/system/exec/tool/UnavailableExternalTool.java
+++ b/system-tools/src/com/braintribe/utils/system/exec/tool/UnavailableExternalTool.java
@@ -1,0 +1,34 @@
+package com.braintribe.utils.system.exec.tool;
+
+import java.util.Collections;
+
+public class UnavailableExternalTool implements ExternalTool {
+
+	private final String id;
+	private final String reason;
+
+	public UnavailableExternalTool(String id, String reason) {
+		this.id = id;
+		this.reason = reason;
+	}
+
+	@Override
+	public String id() {
+		return id;
+	}
+
+	@Override
+	public ToolAvailability availability() {
+		return ToolAvailability.UNAVAILABLE;
+	}
+
+	@Override
+	public ToolDescriptor descriptor() {
+		return new ToolDescriptor(id, "unconfigured", Collections.<String>emptyList(), ToolAvailability.UNAVAILABLE, reason);
+	}
+
+	@Override
+	public ToolExecution openExecution() {
+		throw new IllegalStateException("External tool '" + id + "' is unavailable: " + reason);
+	}
+}


### PR DESCRIPTION
## Summary
- introduce a neutral external-tool registry and execution API
- provide exception-safe per-execution workspaces plus externally managed shared spaces
- support tool-bound and multi-tool execution scopes
- add optional working-directory support to the existing command executor

## Compatibility
- existing command execution remains unchanged unless a working directory is supplied
- CX consumers can continue using their current command/path wiring
- container and modeled configuration concerns remain outside this central API

## Validation
- complete system-tools test suite
- full `hc .` group build
- `git diff --check`